### PR TITLE
Provide prompt to choose new name on overwrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "git2",
+ "indoc",
  "serde",
  "toml",
 ]
@@ -202,6 +203,15 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indoc"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+dependencies = [
+ "unindent",
 ]
 
 [[package]]
@@ -502,6 +512,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unindent"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,6 @@ console = "0.13"
 dialoguer = "0.7"
 dirs = "3"
 git2 = { version = "0.13", default-features = false }
+indoc = "1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"


### PR DESCRIPTION
If a config's name would cause it to overwrite an existing config, this
will ask the user if they intend to overwrite the config. If they choose
not to overwrite, they can enter a new name instead.

Resolves #21
