### PR TITLE
Allow user to specify data filepath from CLI

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -2,8 +2,9 @@ use crate::{write_users, User, Users};
 use anyhow::Result;
 use clap::ArgMatches;
 use console::style;
+use std::path::Path;
 
-pub fn main<'a>(mut users: Users, matches: &ArgMatches<'a>) -> Result<()> {
+pub fn main<'a, P: AsRef<Path>>(mut users: Users, matches: &ArgMatches<'a>, path: P) -> Result<()> {
     let name = matches.value_of("user.name").unwrap();
     let email = matches.value_of("user.email").unwrap();
     let signing_key = matches.value_of("user.signingkey").map(String::from);
@@ -33,5 +34,5 @@ pub fn main<'a>(mut users: Users, matches: &ArgMatches<'a>) -> Result<()> {
     }
     users.insert(alias, user);
 
-    write_users(&users)
+    write_users(&users, path)
 }

--- a/src/cli/delete.rs
+++ b/src/cli/delete.rs
@@ -1,13 +1,14 @@
 use crate::{write_users, Users};
 use anyhow::Result;
 use clap::ArgMatches;
+use std::path::Path;
 
-pub fn main<'a>(mut users: Users, matches: &ArgMatches<'a>) -> Result<()> {
+pub fn main<'a, P: AsRef<Path>>(mut users: Users, matches: &ArgMatches<'a>, path: P) -> Result<()> {
     let selections = matches.values_of("names").unwrap();
 
     for key in selections {
         users.remove(key);
     }
 
-    write_users(&users)
+    write_users(&users, path)
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -119,6 +119,12 @@ impl<'a> Cli<'a> {
         result.context("Couldn't process CLI")
     }
 
+    pub fn data_filepath(&self) -> Result<&OsStr> {
+        self.matches
+            .value_of_os("data file")
+            .context("No value for data filepath")
+    }
+
     /// Was a CLI sub-command used.
     /// i.e. Should interactive prompt not be displayed.
     pub fn used(&self) -> bool {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use clap::{
     crate_description, crate_name, crate_version, App, AppSettings, Arg, ArgMatches, SubCommand,
 };
+use std::ffi::OsStr;
 
 const AFTER_HELP: &str = "Execute without any sub-commands \
 to start an interactive prompt";
@@ -12,7 +13,7 @@ pub struct Cli<'a> {
 }
 
 impl<'a> Cli<'a> {
-    pub fn new() -> Cli<'a> {
+    pub fn new(data_filepath: &'a OsStr) -> Cli<'a> {
         let add = SubCommand::with_name("add")
             .about("Add a set of git config settings")
             .arg(
@@ -80,7 +81,7 @@ impl<'a> Cli<'a> {
                     .help("Name of the set of config settings to view"),
             );
 
-        let matches = App::new(crate_name!())
+        let app = App::new(crate_name!())
             .version(crate_version!())
             .about(crate_description!())
             .after_help(AFTER_HELP)
@@ -88,8 +89,17 @@ impl<'a> Cli<'a> {
             .subcommand(add)
             .subcommand(select)
             .subcommand(delete)
-            .subcommand(view)
-            .get_matches();
+            .subcommand(view);
+
+        let data_file = Arg::with_name("data file")
+            .takes_value(true)
+            .long("data-file")
+            .value_name("filepath")
+            .default_value_os(data_filepath);
+
+        let app = app.arg(data_file);
+
+        let matches = app.get_matches();
 
         Cli { matches }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -106,11 +106,19 @@ impl<'a> Cli<'a> {
 
     pub fn main(&self, users: Users) -> Result<()> {
         let result = if let Some(matches) = self.matches.subcommand_matches("add") {
-            add::main(users, matches)
+            add::main(
+                users,
+                matches,
+                self.data_filepath().context("Couldn't add user")?,
+            )
         } else if let Some(matches) = self.matches.subcommand_matches("select") {
             select::main(users, matches)
         } else if let Some(matches) = self.matches.subcommand_matches("delete") {
-            delete::main(users, matches)
+            delete::main(
+                users,
+                matches,
+                self.data_filepath().context("Couldn't delete user")?,
+            )
         } else if let Some(matches) = self.matches.subcommand_matches("view") {
             view::main(users, matches)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,26 +2,29 @@ use anyhow::{Context, Result};
 pub use config::change_config;
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Select};
-use std::{fmt, path::PathBuf};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 pub use user::{User, Users};
 
 const DATA_FILENAME: &str = "change-git-user.users.toml";
 
 fn main() -> Result<()> {
-    let users = read_users();
-
-    let users = match users {
-        Some(Ok(users)) => users,
-        Some(Err(e)) => return Err(e),
-        None => Users::default(),
-    };
-
     let data_dir = dirs::data_local_dir()
         .map(|p: PathBuf| p.join(DATA_FILENAME))
         .unwrap();
     let data_dir = data_dir.as_os_str();
 
     let cli = cli::Cli::new(data_dir);
+
+    let users = read_users(cli.data_filepath().context("Couldn't read user data")?);
+
+    let users = match users {
+        Some(Ok(users)) => users,
+        Some(Err(e)) => return Err(e),
+        None => Users::default(),
+    };
 
     if cli.used() {
         return cli.main(users);
@@ -51,35 +54,38 @@ fn main() -> Result<()> {
         None => return Ok(()),
     };
 
+    let data_filepath = cli.data_filepath();
     match selection {
-        ActionChoice::Add => prompts::add::main(users, term, theme),
+        ActionChoice::Add => prompts::add::main(
+            users,
+            term,
+            theme,
+            data_filepath.context("Couldn't start user add prompt")?,
+        ),
         ActionChoice::Select => prompts::select::main(users, term, theme),
-        ActionChoice::Delete => prompts::delete::main(users, term, theme),
+        ActionChoice::Delete => prompts::delete::main(
+            users,
+            term,
+            theme,
+            data_filepath.context("Couldn't start user delete prompt")?,
+        ),
     }
 }
 
-fn data_dir() -> Result<PathBuf> {
-    dirs::data_local_dir().context("Couldn't find data directory")
-}
-
-fn read_users() -> Option<Result<Users>> {
+fn read_users<P: AsRef<Path>>(path: P) -> Option<Result<Users>> {
     use std::fs;
 
-    let base = match data_dir() {
-        Ok(dir) => dir,
-        Err(e) => return Some(Err(e)),
-    };
-    let bytes = fs::read(base.join(DATA_FILENAME)).ok()?;
+    let bytes = fs::read(path).ok()?;
     let users: Result<Users> = toml::from_slice(&bytes).context("Failed to parse users");
     Some(users)
 }
 
-fn write_users(users: &Users) -> Result<()> {
+fn write_users<P: AsRef<Path>>(users: &Users, path: P) -> Result<()> {
     use std::fs;
 
     let users = toml::to_string(users).context("Failed to write users to TOML")?;
 
-    fs::write(data_dir()?.join(DATA_FILENAME), users).context("Failed to write users to file")
+    fs::write(path, users).context("Failed to write users to file")
 }
 
 enum ActionChoice {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,12 @@ fn main() -> Result<()> {
         None => Users::default(),
     };
 
-    let cli = cli::Cli::new();
+    let data_dir = dirs::data_local_dir()
+        .map(|p: PathBuf| p.join(DATA_FILENAME))
+        .unwrap();
+    let data_dir = data_dir.as_os_str();
+
+    let cli = cli::Cli::new(data_dir);
 
     if cli.used() {
         return cli.main(users);

--- a/src/prompts/add.rs
+++ b/src/prompts/add.rs
@@ -2,8 +2,14 @@ use crate::{change_config, write_users, User, Users};
 use anyhow::Result;
 use console::{style, Term};
 use dialoguer::{theme::ColorfulTheme, Confirm, Input};
+use std::path::Path;
 
-pub fn main(mut users: Users, term: Term, theme: ColorfulTheme) -> Result<()> {
+pub fn main<P: AsRef<Path>>(
+    mut users: Users,
+    term: Term,
+    theme: ColorfulTheme,
+    path: P,
+) -> Result<()> {
     let name: String = Input::with_theme(&theme)
         .with_prompt("user.name")
         .interact_text_on(&term)?;
@@ -75,5 +81,5 @@ pub fn main(mut users: Users, term: Term, theme: ColorfulTheme) -> Result<()> {
     }
     users.insert(alias, user);
 
-    write_users(&users)
+    write_users(&users, path)
 }

--- a/src/prompts/delete.rs
+++ b/src/prompts/delete.rs
@@ -2,8 +2,14 @@ use crate::{write_users, Users};
 use anyhow::Result;
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, MultiSelect};
+use std::path::Path;
 
-pub fn main(mut users: Users, term: Term, theme: ColorfulTheme) -> Result<()> {
+pub fn main<P: AsRef<Path>>(
+    mut users: Users,
+    term: Term,
+    theme: ColorfulTheme,
+    path: P,
+) -> Result<()> {
     let keys: Vec<_> = users.keys().map(String::from).collect();
 
     let selections = MultiSelect::with_theme(&theme)
@@ -15,5 +21,5 @@ pub fn main(mut users: Users, term: Term, theme: ColorfulTheme) -> Result<()> {
         users.remove(key);
     }
 
-    write_users(&users)
+    write_users(&users, path)
 }


### PR DESCRIPTION
Allows the user to optionally choose an alternate file to store the git config data.

Resolves #27
