### PR TITLE
Allow exiting from prompts that hide cursor

### DIFF
--- a/src/prompts/add.rs
+++ b/src/prompts/add.rs
@@ -57,7 +57,12 @@ pub fn main<P: AsRef<Path>>(
     let switch_user = Confirm::with_theme(&theme)
         .with_prompt("Switch to this user?")
         .default(true)
-        .interact_on(&term)?;
+        .interact_on_opt(&term)?;
+
+    let switch_user = match switch_user {
+        Some(b) => b,
+        None => return Ok(()),
+    };
 
     if switch_user {
         change_config(&user)?;

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -1,5 +1,5 @@
 use crate::{change_config, Users};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use console::Term;
 use dialoguer::{theme::ColorfulTheme, Select};
 
@@ -9,7 +9,9 @@ pub fn main(users: Users, term: Term, theme: ColorfulTheme) -> Result<()> {
     let selection = Select::with_theme(&theme)
         .with_prompt("Select a git config:")
         .items(&keys)
-        .interact_on(&term)?;
+        .interact_on_opt(&term)?;
+
+    let selection = selection.context("User exited without making a selection")?;
 
     let selection = &users[keys[selection]];
 


### PR DESCRIPTION
Allows the user to exit from prompts that hide the cursor, so that the user always has the option to take no action *without* having to deal with a hidden cursor afterwards.

- Allows exiting from initial prompt to select action
- Allows exiting from "Switch to this user?" confirmation prompt in the "Add a new user config" action

Addresses #7 